### PR TITLE
Update FineTune.py

### DIFF
--- a/FineTune.py
+++ b/FineTune.py
@@ -119,14 +119,14 @@ def adjust_batch_size(train_dataloader, max_mem_alloc):
 num_epochs = 1
 max_mem_alloc = 4 
 
+# Adjust batch size if necessary based on available memory
+train_dataloader = adjust_batch_size(train_dataloader, max_mem_alloc)
+
 for epoch in range(num_epochs):
 
     print(f"Starting epoch {epoch + 1}/{num_epochs}")
 
     for step, batch in enumerate(train_dataloader):
-
-        # Adjust batch size if necessary based on available memory
-        train_dataloader = adjust_batch_size(train_dataloader, max_mem_alloc)
 
         images, descriptions = batch
 


### PR DESCRIPTION
A moins que je rate un point, mieux vaut redéfinir la taille de batch _avant_ d'utiliser le DataLoader (même si en l'occurence tu défini déjà le batch à 1) . Du coup je le sort complétement des boucles pour pas le redéfinir à chaque epoch non plus.

D'ailleurs **adjust_batch_size** devrait diviser la batch size tant que la condition est pas respectée en pratique, avec un base case d'erreur si 1 image c'est trop.

Et dernier point, toujours pour **adjust_batch_size** : il faut que tu regarde la mémoire libre, aka la place encore dispo pour tes batchs, je pense, pas la mémoire déjà allouée
```
t = torch.cuda.get_device_properties(0).total_memory
r = torch.cuda.memory_reserved(0)
a = torch.cuda.memory_allocated(0)
f = r-a  # memoire libre dans la memoire reservee
```